### PR TITLE
Ensure we don't re-encode pre-encoded values for +var and #var #7

### DIFF
--- a/lib/URI/Template.pm
+++ b/lib/URI/Template.pm
@@ -36,9 +36,20 @@ sub new {
 sub _quote {
     my ( $val, $safe ) = @_;
     $safe ||= '';
+    my $unsafe = '^A-Za-z0-9\-\._' . $safe;
+
+    ## Where RESERVED are allowed to pass-through, so are
+    ## already-pct-encoded values
+    if( $safe ) {
+        my (@chunks) = split(/(%[0-9A-Fa-f]{2})/, $val);
+
+        return join('',
+                    map { $_ !~ /%[0-9A-Fa-f]{2}/
+                          ? URI::Escape::uri_escape_utf8( Unicode::Normalize::NFKC( $_ ), $unsafe )
+                          : $_ } @chunks);
+    }
 
     # try to mirror python's urllib quote
-    my $unsafe = '^A-Za-z0-9\-\._' . $safe;
     return URI::Escape::uri_escape_utf8( Unicode::Normalize::NFKC( $val ),
         $unsafe );
 }

--- a/lib/URI/Template.pm
+++ b/lib/URI/Template.pm
@@ -43,10 +43,12 @@ sub _quote {
     if( $safe ) {
         my (@chunks) = split(/(%[0-9A-Fa-f]{2})/, $val);
 
-        return join('',
-                    map { $_ !~ /%[0-9A-Fa-f]{2}/
-                          ? URI::Escape::uri_escape_utf8( Unicode::Normalize::NFKC( $_ ), $unsafe )
-                          : $_ } @chunks);
+        # even chunks are not %xx, odd chunks are
+        return join '',
+            map { $_ % 2
+                  ? $chunks[$_]
+                  : URI::Escape::uri_escape_utf8( Unicode::Normalize::NFKC($chunks[$_]), $unsafe ) } 0..$#chunks;
+
     }
 
     # try to mirror python's urllib quote


### PR DESCRIPTION
Using split capture magic to only encode the non-encoded parts of the input value (only for +/#, i.e. when $safe is set..

This makes all the new tests pass.
